### PR TITLE
Add theme toggle, modals, and UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>poc2</title>
+    <meta name="color-scheme" content="light dark" />
+    <title>AidKit (POC2)</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,62 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import './app.css'
 import Chat, { ChatHandle } from './components/Chat'
+import { Theme, getTheme, setTheme, applyTheme } from './lib/theme'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
+  const [theme, setThemeState] = useState<Theme>(() => getTheme())
+  const [aboutOpen, setAboutOpen] = useState(false)
+  const [privacyOpen, setPrivacyOpen] = useState(false)
+
+  const toggleTheme = () => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark'
+    setThemeState(next)
+    setTheme(next)
+    applyTheme(next)
+  }
 
   return (
     <div className="min-h-screen flex flex-col bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
       <header className="fixed top-0 left-0 right-0 z-20 border-b bg-white/80 dark:bg-neutral-900/80 backdrop-blur shadow-sm">
         <div className="mx-auto flex items-center justify-between w-full max-w-[720px] px-4 py-2">
           <h1 className="text-lg font-semibold">AidKit (POC2)</h1>
-          <button
-            onClick={() => chatRef.current?.clear()}
-            className="text-sm text-blue-600 hover:underline"
-          >
-            Clear
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={toggleTheme}
+              aria-label="Toggle theme"
+              className="text-lg"
+            >
+              {theme === 'dark' ? '🌙' : '☀️'}
+            </button>
+            <button
+              onClick={() => chatRef.current?.clear()}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Clear
+            </button>
+          </div>
         </div>
       </header>
       <main className="flex-1 mx-auto w-full max-w-[720px] px-4 pt-16 pb-4">
         <Chat ref={chatRef} />
       </main>
       <footer className="text-xs text-center text-neutral-500 dark:text-neutral-400 py-4">
-        About • Privacy • v0.1
+        <button onClick={() => setAboutOpen(true)} className="underline">About</button> •{' '}
+        <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1
       </footer>
+      <dialog open={aboutOpen} onClose={() => setAboutOpen(false)} className="p-4 rounded-md max-w-sm w-full">
+        <p className="mb-2">AidKit POC2 v0.1</p>
+        <form method="dialog">
+          <button className="underline text-blue-600">Close</button>
+        </form>
+      </dialog>
+      <dialog open={privacyOpen} onClose={() => setPrivacyOpen(false)} className="p-4 rounded-md max-w-sm w-full">
+        <p className="mb-2">POC2: no data leaves your browser.</p>
+        <form method="dialog">
+          <button className="underline text-blue-600">Close</button>
+        </form>
+      </dialog>
     </div>
   )
 }

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -34,6 +34,14 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
     resize()
   }, [value])
 
+  useEffect(() => {
+    if (!streaming) textareaRef.current?.focus()
+  }, [streaming])
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
   return (
     <form onSubmit={e => { e.preventDefault(); onSend() }} className="sticky bottom-0 bg-white dark:bg-neutral-900 pt-2">
       <div className="flex items-end gap-2">

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,26 @@
+const THEME_KEY = 'poc2.theme'
+export type Theme = 'light' | 'dark'
+
+export function getTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(THEME_KEY)
+    if (stored === 'light' || stored === 'dark') return stored
+  } catch {}
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function setTheme(theme: Theme) {
+  try {
+    localStorage.setItem(THEME_KEY, theme)
+  } catch {}
+}
+
+export function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark') root.classList.add('dark')
+  else root.classList.remove('dark')
+}
+
+export function initTheme() {
+  applyTheme(getTheme())
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { initTheme } from './lib/theme'
+
+initTheme()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- Update index metadata for color-scheme and new title
- Persist user-selected light/dark theme and allow toggling in header
- Convert About/Privacy footer links to dialogs and auto-focus message input

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find name 'Map'; try changing the 'lib' compiler option to 'es2015' or later)*

------
https://chatgpt.com/codex/tasks/task_e_6898ba1f76f0832f843fa066ad6f83c1