### PR TITLE
fix mobile message input layout

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -43,12 +43,18 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
   }, [])
 
   return (
-    <form onSubmit={e => { e.preventDefault(); onSend() }} className="sticky bottom-0 bg-white dark:bg-neutral-900 pt-2">
-      <div className="flex items-end gap-2">
+    <form
+      onSubmit={e => {
+        e.preventDefault()
+        onSend()
+      }}
+      className="sticky bottom-0 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
+    >
+      <div className="flex items-end gap-2 w-full overflow-hidden">
         <textarea
           ref={textareaRef}
           aria-label="Message"
-          className="flex-1 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-sm md:text-base text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
+          className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-sm md:text-base text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
           value={value}
           onChange={handleChange}
           onKeyDown={handleKey}
@@ -56,11 +62,22 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
           rows={1}
         />
         {streaming ? (
-          <button type="button" onClick={onStop} aria-label="Stop generation" className="h-11 px-4 rounded-md bg-red-600 text-white">
+          <button
+            type="button"
+            onClick={onStop}
+            aria-label="Stop generation"
+            className="h-11 px-4 rounded-md bg-red-600 text-white shrink-0"
+          >
             Stop
           </button>
         ) : (
-          <button type="submit" onClick={onSend} aria-label="Send" disabled={!value.trim()} className="h-11 px-4 rounded-md bg-blue-600 text-white disabled:opacity-50">
+          <button
+            type="submit"
+            onClick={onSend}
+            aria-label="Send"
+            disabled={!value.trim()}
+            className="h-11 px-4 rounded-md bg-blue-600 text-white disabled:opacity-50 shrink-0"
+          >
             Send
           </button>
         )}


### PR DESCRIPTION
## Summary
- prevent message input form from pushing send button offscreen on small devices
- add safe-area inset bottom padding for iOS home indicator

## Testing
- `npm run build` *(fails: Cannot find name 'Map', 'Set', 'Symbol' in node_modules/vite/types)*

------
https://chatgpt.com/codex/tasks/task_e_6898c0f5b5f8832fbad1938cc8c3fe02