### PR TITLE
fix: prevent iOS zoom from hiding Send button

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <title>AidKit (POC2)</title>
   </head>

--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,6 @@
 /* custom styles */
+
+/* Prevent iOS zoom on focus by ensuring 16px+ controls */
+@supports (-webkit-touch-callout: none) {
+  input, textarea, select, button { font-size: 16px; }
+}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -54,19 +54,19 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
         <textarea
           ref={textareaRef}
           aria-label="Message"
-          className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-sm md:text-base text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
-          value={value}
-          onChange={handleChange}
-          onKeyDown={handleKey}
-          disabled={streaming}
-          rows={1}
+            className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
+            value={value}
+            onChange={handleChange}
+            onKeyDown={handleKey}
+            disabled={streaming}
+            rows={1}
         />
         {streaming ? (
           <button
             type="button"
             onClick={onStop}
             aria-label="Stop generation"
-            className="h-11 px-4 rounded-md bg-red-600 text-white shrink-0"
+            className="h-11 px-4 rounded-md bg-red-600 text-white text-base shrink-0"
           >
             Stop
           </button>
@@ -76,7 +76,7 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
             onClick={onSend}
             aria-label="Send"
             disabled={!value.trim()}
-            className="h-11 px-4 rounded-md bg-blue-600 text-white disabled:opacity-50 shrink-0"
+            className="h-11 px-4 rounded-md bg-blue-600 text-white text-base disabled:opacity-50 shrink-0"
           >
             Send
           </button>


### PR DESCRIPTION
## Summary
- ensure message input and buttons use 16px+ fonts to stop iOS zoom
- set viewport for iOS safe-area and prevent zoom

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find name 'Map'; target library may need ES2015)*

------
https://chatgpt.com/codex/tasks/task_e_6898c31e5460832fae77abc409335a02