### PR TITLE
feat: send messages with enter key

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -12,7 +12,10 @@ export default function MessageBubble({ role, text, isStreaming }: Props) {
   const assistant = 'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100 rounded-bl-none after:absolute after:left-0 after:bottom-0 after:-ml-2 after:w-0 after:h-0 after:border-r-8 after:border-r-neutral-100 dark:after:border-r-neutral-800 after:border-t-8 after:border-t-transparent'
   return (
     <div className={`flex ${role === 'user' ? 'justify-end' : 'justify-start'}`}>
-      <div className={`${base} ${role === 'user' ? user : assistant}`}>
+      <div
+        className={`${base} ${role === 'user' ? user : assistant}`}
+        aria-live={role === 'assistant' ? 'polite' : undefined}
+      >
         {text}
         {isStreaming && (
           <span className="inline-flex ml-1 gap-1 align-bottom">

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -51,34 +51,31 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
       className="sticky bottom-0 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
     >
       <div className="flex items-end gap-2 w-full overflow-hidden">
-        <textarea
-          ref={textareaRef}
-          aria-label="Message"
+        <div className="flex-1 min-w-0 flex flex-col">
+          <textarea
+            ref={textareaRef}
+            aria-label="Message"
+            enterKeyHint="send"
+            autoFocus
             className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
             value={value}
             onChange={handleChange}
             onKeyDown={handleKey}
             disabled={streaming}
             rows={1}
-        />
-        {streaming ? (
+          />
+          <p className="mt-1 hidden md:block text-xs text-neutral-500">
+            Press Enter to send · Shift+Enter for newline
+          </p>
+        </div>
+        {streaming && (
           <button
             type="button"
             onClick={onStop}
             aria-label="Stop generation"
-            className="h-11 px-4 rounded-md bg-red-600 text-white text-base shrink-0"
+            className="h-8 px-3 rounded-full bg-red-600 text-white text-sm shrink-0"
           >
             Stop
-          </button>
-        ) : (
-          <button
-            type="submit"
-            onClick={onSend}
-            aria-label="Send"
-            disabled={!value.trim()}
-            className="h-11 px-4 rounded-md bg-blue-600 text-white text-base disabled:opacity-50 shrink-0"
-          >
-            Send
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- remove send button and submit messages via Enter key
- add desktop-only hint for using Enter vs Shift+Enter
- announce assistant replies with aria-live for screen readers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find name 'Set' and other TypeScript lib errors)


------
https://chatgpt.com/codex/tasks/task_e_6898c4b09524832fb2ab7887eb6a4c9e