### PR TITLE
fix footer visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,10 +38,10 @@ export default function App() {
           </div>
         </div>
       </header>
-      <main className="flex-1 mx-auto w-full max-w-[720px] px-4 pt-16 pb-4">
+      <main className="flex-1 mx-auto w-full max-w-[720px] px-4 pt-16 pb-16">
         <Chat ref={chatRef} />
       </main>
-      <footer className="text-xs text-center text-neutral-500 dark:text-neutral-400 py-4">
+      <footer className="fixed bottom-0 left-0 right-0 text-xs text-center text-neutral-500 dark:text-neutral-400 py-2 bg-white/80 dark:bg-neutral-900/80 backdrop-blur border-t">
         <button onClick={() => setAboutOpen(true)} className="underline">About</button> •{' '}
         <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1
       </footer>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -83,7 +83,7 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-y-auto space-y-4 pb-4">
+      <div className="flex-1 overflow-y-auto space-y-4 pb-4 pb-28">
         {messages.map((m, i) => (
           <MessageBubble
             key={m.id}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -48,7 +48,7 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
         e.preventDefault()
         onSend()
       }}
-      className="sticky bottom-0 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
+      className="sticky bottom-12 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
     >
       <div className="flex items-end gap-2 w-full overflow-hidden">
         <div className="flex-1 min-w-0 flex flex-col">


### PR DESCRIPTION
## Summary
- keep footer visible with fixed position, translucent background, and top border
- push content padding and chat input above footer
- add extra bottom padding to chat messages so scrolling reveals last message

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: tsconfig.json(17,18): error TS6310: Referenced project '/workspace/poc2/tsconfig.node.json' may not disable emit.)

------
https://chatgpt.com/codex/tasks/task_e_6898ce94de1c832fbe484ff06a7d3cfc