### PR TITLE
Add build and commit metadata footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react'
 import './app.css'
 import Chat, { ChatHandle } from './components/Chat'
 import { Theme, getTheme, setTheme, applyTheme } from './lib/theme'
+import { COMMIT_SHA, BUILD_TIME } from './lib/version'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -43,7 +44,8 @@ export default function App() {
       </main>
       <footer className="fixed bottom-0 left-0 right-0 text-xs text-center text-neutral-500 dark:text-neutral-400 py-2 bg-white/80 dark:bg-neutral-900/80 backdrop-blur border-t">
         <button onClick={() => setAboutOpen(true)} className="underline">About</button> •{' '}
-        <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1
+        <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1{' '}
+        <small className="opacity-75">• {COMMIT_SHA} • {new Date(BUILD_TIME).toLocaleString()}</small>
       </footer>
       <dialog open={aboutOpen} onClose={() => setAboutOpen(false)} className="p-4 rounded-md max-w-sm w-full">
         <p className="mb-2">AidKit POC2 v0.1</p>

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,6 @@
+declare const __BUILD_TIME__: string;
+declare const __COMMIT_SHA__: string;
+
+export const BUILD_TIME = __BUILD_TIME__ as string;
+export const COMMIT_SHA = __COMMIT_SHA__ as string;
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from 'vite'
 
-export default defineConfig({})
+export default defineConfig({
+  define: {
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    __COMMIT_SHA__: JSON.stringify(
+      process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || 'dev',
+    ),
+  },
+})


### PR DESCRIPTION
## Summary
- expose build time and short commit SHA via Vite globals
- show commit SHA and build timestamp in footer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: tsconfig.json(17,18): error TS6310)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898d7f2ec98832fb5200bb68f3ea309