### PR TITLE
Add debug overlay and logging utilities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import './app.css'
 import Chat, { ChatHandle } from './components/Chat'
 import { Theme, getTheme, setTheme, applyTheme } from './lib/theme'
 import { COMMIT_SHA, BUILD_TIME } from './lib/version'
+import DebugOverlay from './components/DebugOverlay'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -59,6 +60,7 @@ export default function App() {
           <button className="underline text-blue-600">Close</button>
         </form>
       </dialog>
+      <DebugOverlay />
     </div>
   )
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,5 @@
 /* custom styles */
+html { -webkit-text-size-adjust: 100%; }
 
 /* Prevent iOS zoom on focus by ensuring 16px+ controls */
 @supports (-webkit-touch-callout: none) {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, forwardRef, useImperativeHandle } f
 import { mockChat } from '../services/llm'
 import { getItem, setItem } from '../lib/storage'
 import { uuid } from '../lib/uuid'
+import { log } from '../lib/debug'
 import MessageBubble from './MessageBubble'
 import MessageInput from './MessageInput'
 
@@ -75,6 +76,7 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
         controllerRef.current = undefined
       }
     } catch (err) {
+      log(err)
       console.error(err)
     }
   }

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { isDebug, getLogs, subscribe, clearLogs } from '../lib/debug'
+
+export default function DebugOverlay() {
+  if (!isDebug()) return null
+
+  const [logs, setLogs] = useState<string[]>(getLogs())
+  const scrollRef = useRef<HTMLPreElement>(null)
+
+  useEffect(() => {
+    const unsub = subscribe(() => setLogs([...getLogs()]))
+    return unsub
+  }, [])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [logs])
+
+  return (
+    <div className="fixed z-50 bottom-16 left-2 right-2 max-h-[40vh] rounded-md border border-neutral-300 dark:border-neutral-700 bg-white/90 dark:bg-neutral-900/90 backdrop-blur p-2 text-[12px] font-mono shadow overflow-hidden">
+      <div className="flex justify-between items-center">
+        <span className="font-semibold">Debug</span>
+        <button onClick={clearLogs} className="text-xs text-blue-600">Clear</button>
+      </div>
+      <pre ref={scrollRef} className="mt-1 overflow-auto max-h-[34vh] whitespace-pre-wrap leading-[1.2]">
+        {logs.join('\n')}
+      </pre>
+    </div>
+  )
+}

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,30 @@
+export function isDebug(): boolean {
+  return new URLSearchParams(window.location.search).has('debug')
+}
+
+let logs: string[] = []
+let subs = new Set<() => void>()
+
+export function getLogs() {
+  return logs
+}
+
+export function subscribe(fn: () => void) {
+  subs.add(fn)
+  return () => subs.delete(fn)
+}
+
+export function clearLogs() {
+  logs = []
+  subs.forEach(fn => fn())
+}
+
+export function log(msg: unknown) {
+  const line = typeof msg === 'string' ? msg : JSON.stringify(msg)
+  logs.push(`[${new Date().toLocaleTimeString()}] ${line}`)
+  logs = logs.slice(-200)
+  subs.forEach(fn => fn())
+  try {
+    console.log('[DBG]', msg)
+  } catch {}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,14 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { initTheme } from './lib/theme'
+import { isDebug, log } from './lib/debug'
 
-window.addEventListener('error', e => console.log('window error:', e.message))
-window.addEventListener('unhandledrejection', e => console.log('promise rejection:', e.reason))
+if (isDebug()) {
+  window.addEventListener('error', e => log(`error: ${e.message}`))
+  window.addEventListener('unhandledrejection', e =>
+    log(`unhandled: ${e.reason?.message || e.reason}`)
+  )
+}
 
 initTheme()
 


### PR DESCRIPTION
## Summary
- add URL-param activated debug helpers and log buffer
- display a fixed debug overlay with clearable scrolling log
- capture window errors and promise rejections when debugging

## Testing
- `npm run typecheck` *(fails: Referenced project '/workspace/poc2/tsconfig.node.json' may not disable emit)*

------
https://chatgpt.com/codex/tasks/task_e_6898da900534832f80764321f88f02ed