### PR TITLE
feat: improve theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,15 @@
 import React, { useRef, useState } from 'react'
 import './app.css'
 import Chat, { ChatHandle } from './components/Chat'
-import { Theme, getTheme, setTheme, applyTheme } from './lib/theme'
+import { getTheme, toggleTheme } from './lib/theme'
 import { COMMIT_SHA, BUILD_TIME } from './lib/version'
 import DebugOverlay from './components/DebugOverlay'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
-  const [theme, setThemeState] = useState<Theme>(() => getTheme())
+  const [theme, setThemeState] = useState(() => getTheme())
   const [aboutOpen, setAboutOpen] = useState(false)
   const [privacyOpen, setPrivacyOpen] = useState(false)
-
-  const toggleTheme = () => {
-    const next: Theme = theme === 'dark' ? 'light' : 'dark'
-    setThemeState(next)
-    setTheme(next)
-    applyTheme(next)
-  }
 
   return (
     <div className="min-h-screen flex flex-col bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
@@ -25,8 +18,12 @@ export default function App() {
           <h1 className="text-lg font-semibold">AidKit (POC2)</h1>
           <div className="flex items-center gap-2">
             <button
-              onClick={toggleTheme}
+              onClick={() => {
+                toggleTheme()
+                setThemeState(getTheme())
+              }}
               aria-label="Toggle theme"
+              title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
               className="text-lg"
             >
               {theme === 'dark' ? '🌙' : '☀️'}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,26 +1,37 @@
-const THEME_KEY = 'poc2.theme'
-export type Theme = 'light' | 'dark'
+export type Theme = 'light' | 'dark' | 'system'
+
+const KEY = 'poc2.theme'
+
+function systemPref(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
 
 export function getTheme(): Theme {
-  try {
-    const stored = localStorage.getItem(THEME_KEY)
-    if (stored === 'light' || stored === 'dark') return stored
-  } catch {}
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  return (localStorage.getItem(KEY) as Theme) || 'system'
 }
 
-export function setTheme(theme: Theme) {
-  try {
-    localStorage.setItem(THEME_KEY, theme)
-  } catch {}
-}
-
-export function applyTheme(theme: Theme) {
+export function applyTheme(t: Theme) {
   const root = document.documentElement
-  if (theme === 'dark') root.classList.add('dark')
-  else root.classList.remove('dark')
+  const mode = t === 'system' ? systemPref() : t
+  root.classList.toggle('dark', mode === 'dark')
+  localStorage.setItem(KEY, t)
+}
+
+export function toggleTheme() {
+  const t = getTheme()
+  const next = t === 'dark' ? 'light' : 'dark'
+  applyTheme(next)
 }
 
 export function initTheme() {
+  // run before React renders
   applyTheme(getTheme())
+  // keep in sync with system changes when in 'system'
+  const mq = window.matchMedia('(prefers-color-scheme: dark)')
+  mq.onchange = () => {
+    if (getTheme() === 'system') applyTheme('system')
+  }
 }
+

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode
- implement theme helpers with system-pref support and persistence
- wire toggle button to switch themes in App

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898dfcdaaa8832fbe35b9e2e023a9d4