### PR TITLE
feat: add API-backed chat option

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react'
-import { mockChat } from '../services/llm'
+import { chat } from '../services/llm'
 import { getItem, setItem } from '../lib/storage'
 import { uuid } from '../lib/uuid'
 import { log } from '../lib/debug'
@@ -59,8 +59,8 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
       setStreaming(true)
       const controller = new AbortController()
       controllerRef.current = controller
-      try {
-        for await (const ev of mockChat(content, { signal: controller.signal })) {
+        try {
+          for await (const ev of chat(content, { signal: controller.signal })) {
           if ('token' in ev) {
             setMessages(m =>
               m.map(msg =>


### PR DESCRIPTION
## Summary
- add USE_API flag and apiChat generator to call real /api/chat endpoint
- expose chat helper that selects between apiChat and mockChat
- update Chat component to call chat function for streaming responses

## Testing
- `npm test` (fails: Missing script)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898ead255b8832fb16e46453593cd47