### PR TITLE
feat: add API-backed chat option

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react'
-import { mockChat } from '../services/llm'
+import { chat } from '../services/llm'
 import { getItem, setItem } from '../lib/storage'
 import { uuid } from '../lib/uuid'
 import { log } from '../lib/debug'
@@ -59,8 +59,8 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
       setStreaming(true)
       const controller = new AbortController()
       controllerRef.current = controller
-      try {
-        for await (const ev of mockChat(content, { signal: controller.signal })) {
+        try {
+          for await (const ev of chat(content, { signal: controller.signal })) {
           if ('token' in ev) {
             setMessages(m =>
               m.map(msg =>

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -1,5 +1,7 @@
 export type ChatEvent = { token: string } | { done: true }
 
+const USE_API = true // TODO: wire via Vite define/env later
+
 function delay(ms: number) {
   return new Promise(res => setTimeout(res, ms))
 }
@@ -15,6 +17,45 @@ export async function* mockChat(prompt: string, opts?: { signal?: AbortSignal })
   if (!opts?.signal?.aborted) {
     yield { done: true }
   }
+}
+
+export async function* apiChat(prompt: string, opts?: { signal?: AbortSignal }): AsyncGenerator<ChatEvent> {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages: [{ role: 'user', content: prompt }] }),
+    signal: opts?.signal,
+  })
+  if (!res.ok || !res.body) {
+    yield { token: `⚠️ API ${res.status}` }
+    yield { done: true }
+    return
+  }
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    if (opts?.signal?.aborted) break
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const parts = buffer.split(/\s+/)
+    buffer = parts.pop() ?? ''
+    for (const token of parts) {
+      if (opts?.signal?.aborted) break
+      if (token) yield { token }
+    }
+  }
+  if (!opts?.signal?.aborted) {
+    if (buffer) {
+      yield { token: buffer }
+    }
+    yield { done: true }
+  }
+}
+
+export function chat(prompt: string, opts?: { signal?: AbortSignal }) {
+  return USE_API ? apiChat(prompt, opts) : mockChat(prompt, opts)
 }
 
 export function systemPrompt(): string {


### PR DESCRIPTION
## Summary
- add USE_API flag and apiChat generator to call real /api/chat endpoint
- expose chat helper that selects between apiChat and mockChat
- default to API usage and emit warning token if backend response invalid

## Testing
- `npm test` (fails: Missing script)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898ead255b8832fb16e46453593cd47