### PR TITLE
feat: add about and privacy modals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Chat, { ChatHandle } from './components/Chat'
 import { getTheme, toggleTheme } from './lib/theme'
 import { COMMIT_SHA, BUILD_TIME } from './lib/version'
 import DebugOverlay from './components/DebugOverlay'
+import AboutModal from './components/AboutModal'
+import PrivacyModal from './components/PrivacyModal'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -45,18 +47,8 @@ export default function App() {
         <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1{' '}
         <small className="opacity-75">• {COMMIT_SHA} • {new Date(BUILD_TIME).toLocaleString()}</small>
       </footer>
-      <dialog open={aboutOpen} onClose={() => setAboutOpen(false)} className="p-4 rounded-md max-w-sm w-full">
-        <p className="mb-2">AidKit POC2 v0.1</p>
-        <form method="dialog">
-          <button className="underline text-blue-600">Close</button>
-        </form>
-      </dialog>
-      <dialog open={privacyOpen} onClose={() => setPrivacyOpen(false)} className="p-4 rounded-md max-w-sm w-full">
-        <p className="mb-2">POC2: no data leaves your browser.</p>
-        <form method="dialog">
-          <button className="underline text-blue-600">Close</button>
-        </form>
-      </dialog>
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <PrivacyModal open={privacyOpen} onClose={() => setPrivacyOpen(false)} />
       <DebugOverlay />
     </div>
   )

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function AboutModal({ open, onClose }: Props) {
+  return (
+    <dialog open={open} onClose={onClose} className="p-4 rounded-md max-w-sm w-full">
+      <h2 className="text-lg font-semibold mb-2">About AidKit</h2>
+      <p className="mb-2">AidKit POC2 explores AI-assisted first-aid guidance.</p>
+      <p className="mb-2">Built with React, TypeScript, Vite, and Tailwind CSS.</p>
+      <p className="mb-4">
+        View the source on{' '}
+        <a
+          href="https://github.com/aidkit/poc2"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-600"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+      <form method="dialog">
+        <button className="underline text-blue-600">Close</button>
+      </form>
+    </dialog>
+  )
+}

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -79,6 +79,7 @@ export default function MessageInput({ value, onChange, onSend, onStop, streamin
           </button>
         )}
       </div>
+      <p className="mt-2 text-center text-xs text-neutral-500 dark:text-neutral-400">Not medical advice. In an emergency, call local services.</p>
     </form>
   )
 }

--- a/src/components/PrivacyModal.tsx
+++ b/src/components/PrivacyModal.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function PrivacyModal({ open, onClose }: Props) {
+  return (
+    <dialog open={open} onClose={onClose} className="p-4 rounded-md max-w-sm w-full">
+      <h2 className="text-lg font-semibold mb-2">Privacy</h2>
+      <p className="mb-2">This is a proof of concept.</p>
+      <p className="mb-2">No server-side storage; your data stays in your browser.</p>
+      <p className="mb-4">
+        API calls are proxied through <code>/api/chat</code>.
+      </p>
+      <form method="dialog">
+        <button className="underline text-blue-600">Close</button>
+      </form>
+    </dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add dedicated About and Privacy modals with project details and data usage notes
- wire footer links to open the new modals
- show a safety disclaimer beneath the message input

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run typecheck` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898f586a824832f9b2c28cdfbee05fb