### PR TITLE
Add favicon and social metadata

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#e11d48" d="M10 4h4v16h-4zM4 10h16v4H4z"/></svg>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>AidKit (POC2)</title>
+    <meta name="description" content="A lightweight proof of concept for AidKit." />
+    <meta property="og:title" content="AidKit (POC2)" />
+    <meta property="og:description" content="A lightweight proof of concept for AidKit." />
+    <meta property="og:image" content="/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AidKit (POC2)" />
+    <meta name="twitter:description" content="A lightweight proof of concept for AidKit." />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add lightweight SVG favicon and link it in the document head
- include Open Graph and Twitter card meta tags with placeholder image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898fd4f7598832fbdcdbb5045fd7c8d