### PR TITLE
Fix scroll reset and input refocus on Clear

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 
 interface Props {
   value: string
@@ -7,79 +7,94 @@ interface Props {
   onStop: () => void
   streaming: boolean
 }
+export interface MessageInputHandle {
+  focus: () => void
+}
 
-export default function MessageInput({ value, onChange, onSend, onStop, streaming }: Props) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+const MessageInput = forwardRef<MessageInputHandle, Props>(
+  ({ value, onChange, onSend, onStop, streaming }, ref) => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      onSend()
-    }
-  }
+    useImperativeHandle(ref, () => ({
+      focus() {
+        textareaRef.current?.focus()
+      },
+    }))
 
-  const resize = () => {
-    const el = textareaRef.current
-    if (!el) return
-    el.style.height = 'auto'
-    el.style.height = Math.min(el.scrollHeight, 24 * 6) + 'px'
-  }
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    onChange(e.target.value)
-    resize()
-  }
-
-  useEffect(() => {
-    resize()
-  }, [value])
-
-  useEffect(() => {
-    if (!streaming) textareaRef.current?.focus()
-  }, [streaming])
-
-  useEffect(() => {
-    textareaRef.current?.focus()
-  }, [])
-
-  return (
-    <form
-      onSubmit={e => {
+    const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
         onSend()
-      }}
-      className="sticky bottom-12 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
-    >
-      <div className="flex items-end gap-2 w-full overflow-hidden">
-        <div className="flex-1 min-w-0 flex flex-col">
-          <textarea
-            ref={textareaRef}
-            aria-label="Message"
-            enterKeyHint="send"
-            autoFocus
-            className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
-            value={value}
-            onChange={handleChange}
-            onKeyDown={handleKey}
-            disabled={streaming}
-            rows={1}
-          />
-          <p className="mt-1 hidden md:block text-xs text-neutral-500">
-            Press Enter to send · Shift+Enter for newline
-          </p>
+      }
+    }
+
+    const resize = () => {
+      const el = textareaRef.current
+      if (!el) return
+      el.style.height = 'auto'
+      el.style.height = Math.min(el.scrollHeight, 24 * 6) + 'px'
+    }
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e.target.value)
+      resize()
+    }
+
+    useEffect(() => {
+      resize()
+    }, [value])
+
+    useEffect(() => {
+      if (!streaming) textareaRef.current?.focus()
+    }, [streaming])
+
+    useEffect(() => {
+      textareaRef.current?.focus()
+    }, [])
+
+    return (
+      <form
+        onSubmit={e => {
+          e.preventDefault()
+          onSend()
+        }}
+        className="sticky bottom-12 bg-white dark:bg-neutral-900 pt-2 px-2 pb-[max(env(safe-area-inset-bottom),0px)]"
+      >
+        <div className="flex items-end gap-2 w-full overflow-hidden">
+          <div className="flex-1 min-w-0 flex flex-col">
+            <textarea
+              ref={textareaRef}
+              aria-label="Message"
+              enterKeyHint="send"
+              autoFocus
+              className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
+              value={value}
+              onChange={handleChange}
+              onKeyDown={handleKey}
+              disabled={streaming}
+              rows={1}
+            />
+            <p className="mt-1 hidden md:block text-xs text-neutral-500">
+              Press Enter to send · Shift+Enter for newline
+            </p>
+          </div>
+          {streaming && (
+            <button
+              type="button"
+              onClick={onStop}
+              aria-label="Stop generation"
+              className="h-8 px-3 rounded-full bg-red-600 text-white text-sm shrink-0"
+            >
+              Stop
+            </button>
+          )}
         </div>
-        {streaming && (
-          <button
-            type="button"
-            onClick={onStop}
-            aria-label="Stop generation"
-            className="h-8 px-3 rounded-full bg-red-600 text-white text-sm shrink-0"
-          >
-            Stop
-          </button>
-        )}
-      </div>
-      <p className="mt-2 text-center text-xs text-neutral-500 dark:text-neutral-400">Not medical advice. In an emergency, call local services.</p>
-    </form>
-  )
-}
+        <p className="mt-2 text-center text-xs text-neutral-500 dark:text-neutral-400">Not medical advice. In an emergency, call local services.</p>
+      </form>
+    )
+  }
+)
+
+MessageInput.displayName = 'MessageInput'
+
+export default MessageInput


### PR DESCRIPTION
## Summary
- prevent jump-to-bottom after clearing chat by tracking a skip scroll flag
- allow message input to expose a focus method and re-focus after clearing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68993ac4f948832fbb94645aaea4924b