### PR TITLE
Fix textarea focus ring bleed

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,5 @@
 /* custom styles */
-html { -webkit-text-size-adjust: 100%; }
+html { -webkit-text-size-adjust: 100%; } /* iOS text sizing consistency */
 
 /* Prevent iOS zoom on focus by ensuring 16px+ controls */
 @supports (-webkit-touch-callout: none) {

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -62,18 +62,20 @@ const MessageInput = forwardRef<MessageInputHandle, Props>(
       >
         <div className="flex items-end gap-2 w-full overflow-hidden">
           <div className="flex-1 min-w-0 flex flex-col">
-            <textarea
-              ref={textareaRef}
-              aria-label="Message"
-              enterKeyHint="send"
-              autoFocus
-              className="flex-1 min-w-0 resize-none rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-48 overflow-y-auto"
-              value={value}
-              onChange={handleChange}
-              onKeyDown={handleKey}
-              disabled={streaming}
-              rows={1}
-            />
+            <div className="flex-1 min-w-0 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-0 ring-inset">
+              <textarea
+                ref={textareaRef}
+                aria-label="Message"
+                enterKeyHint="send"
+                autoFocus
+                className="w-full resize-none rounded-lg bg-transparent p-3 text-base md:text-lg text-neutral-900 dark:text-neutral-100 outline-none focus:outline-none focus:ring-0 appearance-none max-h-48 overflow-y-auto"
+                value={value}
+                onChange={handleChange}
+                onKeyDown={handleKey}
+                disabled={streaming}
+                rows={1}
+              />
+            </div>
             <p className="mt-1 hidden md:block text-xs text-neutral-500">
               Press Enter to send · Shift+Enter for newline
             </p>


### PR DESCRIPTION
## Summary
- Move focus ring to a rounded wrapper around the message textarea to prevent blue bleed
- Clarify iOS text sizing with webkit adjustment comment

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68993d2ba860832f9e8e1b4671da8cf0