### PR TITLE
feat: render markdown in assistant messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^9.0.0",
+    "remark-gfm": "^4.0.0",
+    "rehype-sanitize": "^6.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -17,6 +20,7 @@
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
+    "@tailwindcss/typography": "^0.5.13",
     "typescript": "^5.0.0",
     "vite": "^5.4.19"
   }

--- a/src/app.css
+++ b/src/app.css
@@ -5,3 +5,10 @@ html { -webkit-text-size-adjust: 100%; } /* iOS text sizing consistency */
 @supports (-webkit-touch-callout: none) {
   input, textarea, select, button { font-size: 16px; }
 }
+
+/* Markdown typography tweaks */
+.prose { line-height: 1.5; }
+.prose p { margin: 0.5rem 0; }
+.prose :where(h1,h2,h3){ margin: 0.5rem 0; }
+.prose :where(ul,ol){ margin: 0.5rem 0; padding-left: 1.25rem; }
+.prose :where(code){ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeSanitize from 'rehype-sanitize'
 
 interface Props {
   role: 'user' | 'assistant'
@@ -16,7 +19,46 @@ export default function MessageBubble({ role, text, isStreaming }: Props) {
         className={`${base} ${role === 'user' ? user : assistant}`}
         aria-live={role === 'assistant' ? 'polite' : undefined}
       >
-        {text}
+        {role === 'assistant' ? (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeSanitize]}
+            className="prose prose-sm dark:prose-invert max-w-none"
+            components={{
+              p: ({ node, ...props }: any) => <p className="my-2 leading-relaxed" {...props} />,
+              ul: ({ node, ...props }: any) => <ul className="my-2 ml-5 list-disc" {...props} />,
+              ol: ({ node, ...props }: any) => <ol className="my-2 ml-5 list-decimal" {...props} />,
+              li: ({ node, ...props }: any) => <li className="my-1" {...props} />,
+              h1: (props: any) => <h1 className="text-lg font-semibold mt-3 mb-2" {...props} />,
+              h2: (props: any) => <h2 className="text-base font-semibold mt-3 mb-2" {...props} />,
+              h3: (props: any) => <h3 className="text-sm font-semibold mt-3 mb-1" {...props} />,
+              code: ({ inline, ...props }: any) =>
+                inline ? (
+                  <code
+                    className="px-1 py-0.5 rounded bg-neutral-200 dark:bg-neutral-700"
+                    {...props}
+                  />
+                ) : (
+                  <pre
+                    className="p-2 rounded bg-neutral-900 text-neutral-100 overflow-auto"
+                    {...props}
+                  />
+                ),
+              a: ({ node, ...props }: any) => (
+                <a
+                  className="underline text-blue-600"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  {...props}
+                />
+              ),
+            }}
+          >
+            {text}
+          </ReactMarkdown>
+        ) : (
+          text
+        )}
         {isStreaming && (
           <span className="inline-flex ml-1 gap-1 align-bottom">
             <span className="w-1.5 h-1.5 rounded-full bg-current animate-bounce [animation-delay:-0.3s]"></span>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,5 +4,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Summary
- render assistant chat messages using `ReactMarkdown` with GFM and sanitization
- tweak message styling and prose typography
- configure Tailwind Typography plugin and markdown CSS helpers

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react-markdown' or its corresponding type declarations)*
- `npm run build` *(fails: Cannot find module '@tailwindcss/typography')*

------
https://chatgpt.com/codex/tasks/task_e_68993f2e9694832f9876c0fc4b915119