### PR TITLE
Render Markdown correctly for assistant responses

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -80,7 +80,7 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
             setMessages(m =>
               m.map(msg =>
                 msg.id === assistantMsg.id
-                  ? { ...msg, text: msg.text + (msg.text ? ' ' : '') + ev.token }
+                  ? { ...msg, text: msg.text + ev.token }
                   : msg
               )
             )
@@ -127,7 +127,7 @@ const Chat = forwardRef<ChatHandle>((_, ref) => {
             setMessages(m =>
               m.map(msg =>
                 msg.id === last.id
-                  ? { ...msg, text: msg.text + (msg.text ? ' ' : '') + ev.token }
+                  ? { ...msg, text: msg.text + ev.token }
                   : msg
               )
             )

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -10,8 +10,8 @@ interface Props {
 }
 
 export default function MessageBubble({ role, text, isStreaming }: Props) {
-  const base = "relative max-w-[80%] md:max-w-[70%] whitespace-pre-wrap px-4 py-2 text-sm md:text-base rounded-2xl shadow after:content-['']"
-  const user = 'bg-blue-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-blue-600 after:border-t-8 after:border-t-transparent'
+  const base = "relative max-w-[80%] md:max-w-[70%] px-4 py-2 text-sm md:text-base rounded-2xl shadow after:content-['']"
+  const user = 'whitespace-pre-wrap bg-blue-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-blue-600 after:border-t-8 after:border-t-transparent'
   const assistant = 'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100 rounded-bl-none after:absolute after:left-0 after:bottom-0 after:-ml-2 after:w-0 after:h-0 after:border-r-8 after:border-r-neutral-100 dark:after:border-r-neutral-800 after:border-t-8 after:border-t-transparent'
   return (
     <div className={`flex ${role === 'user' ? 'justify-end' : 'justify-start'}`}>

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -10,12 +10,23 @@ export async function* mockChat(
   prompt: string,
   opts?: { signal?: AbortSignal; history?: { role: string; content: string }[]; system?: string }
 ): AsyncGenerator<ChatEvent> {
-  const text = 'Remember to stay calm and check for safety before giving first aid.'
-  const tokens = text.split(' ')
-  for (const token of tokens) {
+  const md = [
+    "Here’s a step-by-step guide for performing mouth-to-mouth:",
+    "",
+    "### Steps for Mouth-to-Mouth Resuscitation",
+    "1. **Ensure Safety**",
+    "   - Make sure the area is safe for both you and the victim.",
+    "2. **Check Responsiveness**",
+    "   - Tap and shout; if no response, call emergency services.",
+    "",
+    "**Disclaimer:** General first-aid guidance, not medical diagnosis.",
+  ].join("\n")
+
+  const tokens = md.match(/(\n+|\s+|[^\s]+)/g) ?? []
+  for (const t of tokens) {
     if (opts?.signal?.aborted) break
-    await delay(40 + Math.random() * 20)
-    yield { token }
+    await delay(35 + Math.random() * 20)
+    yield { token: t }
   }
   if (!opts?.signal?.aborted) {
     yield { done: true }


### PR DESCRIPTION
## Summary
- Stream mock assistant output as Markdown with preserved whitespace
- Append streamed tokens directly without extra spacing
- Remove whitespace-pre-wrap from assistant bubbles while keeping `prose` styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899421035dc832fa48ac69c0bebeaa6