### PR TITLE
Add persona selection with AidKit and Digital Friend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { COMMIT_SHA, BUILD_TIME } from './lib/version'
 import DebugOverlay from './components/DebugOverlay'
 import AboutModal from './components/AboutModal'
 import PrivacyModal from './components/PrivacyModal'
+import { getPersona } from './personas'
+import { getItem, setItem } from './lib/storage'
+import { isDebug } from './lib/debug'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -13,11 +16,21 @@ export default function App() {
   const [aboutOpen, setAboutOpen] = useState(false)
   const [privacyOpen, setPrivacyOpen] = useState(false)
 
+  const [{ key: personaKey, persona }] = useState(() => {
+    const params = new URLSearchParams(window.location.search)
+    const urlKey = params.get('persona')
+    const storedKey = getItem('poc2.persona')
+    const { key, persona } = getPersona(urlKey || storedKey || undefined)
+    setItem('poc2.persona', key)
+    document.title = persona.title
+    return { key, persona }
+  })
+
   return (
     <div className="min-h-screen flex flex-col bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
       <header className="fixed top-0 left-0 right-0 z-20 border-b bg-white/80 dark:bg-neutral-900/80 backdrop-blur shadow-sm">
         <div className="mx-auto flex items-center justify-between w-full max-w-[720px] px-4 py-2">
-          <h1 className="text-lg font-semibold">AidKit (POC2)</h1>
+          <h1 className="text-lg font-semibold">{persona.title}</h1>
           <div className="flex items-center gap-2">
             <button
               onClick={() => {
@@ -40,12 +53,22 @@ export default function App() {
         </div>
       </header>
       <main className="flex-1 mx-auto w-full max-w-[720px] px-4 pt-16 pb-16">
-        <Chat ref={chatRef} />
+        <Chat ref={chatRef} persona={persona} personaKey={personaKey} />
       </main>
       <footer className="fixed bottom-0 left-0 right-0 text-xs text-center text-neutral-500 dark:text-neutral-400 py-2 bg-white/80 dark:bg-neutral-900/80 backdrop-blur border-t">
         <button onClick={() => setAboutOpen(true)} className="underline">About</button> •{' '}
         <button onClick={() => setPrivacyOpen(true)} className="underline">Privacy</button> • v0.1{' '}
         <small className="opacity-75">• {COMMIT_SHA} • {new Date(BUILD_TIME).toLocaleString()}</small>
+        {isDebug() && (
+          <div className="mt-1">
+            <a href="?persona=aidkit&debug=1" className="underline mr-2">
+              AidKit
+            </a>
+            <a href="?persona=friend&debug=1" className="underline">
+              Friend
+            </a>
+          </div>
+        )}
       </footer>
       <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
       <PrivacyModal open={privacyOpen} onClose={() => setPrivacyOpen(false)} />

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -2,17 +2,19 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeSanitize from 'rehype-sanitize'
+import { Persona } from '../personas'
 
 interface Props {
   role: 'user' | 'assistant'
   text: string
   isStreaming?: boolean
+  persona: Persona
 }
 
-export default function MessageBubble({ role, text, isStreaming }: Props) {
+export default function MessageBubble({ role, text, isStreaming, persona }: Props) {
   const base = "relative max-w-[80%] md:max-w-[70%] px-4 py-2 text-sm md:text-base rounded-2xl shadow after:content-['']"
-  const user = 'whitespace-pre-wrap bg-blue-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-blue-600 after:border-t-8 after:border-t-transparent'
-  const assistant = 'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100 rounded-bl-none after:absolute after:left-0 after:bottom-0 after:-ml-2 after:w-0 after:h-0 after:border-r-8 after:border-r-neutral-100 dark:after:border-r-neutral-800 after:border-t-8 after:border-t-transparent'
+  const user = persona.bubbles.user
+  const assistant = persona.bubbles.assistant
   return (
     <div className={`flex ${role === 'user' ? 'justify-end' : 'justify-start'}`}>
       <div

--- a/src/personas.ts
+++ b/src/personas.ts
@@ -1,0 +1,40 @@
+export type PersonaKey = 'aidkit' | 'friend'
+
+export interface Persona {
+  title: string
+  systemPrompt: string
+  bubbles: {
+    user: string
+    assistant: string
+  }
+}
+
+export const PERSONAS: Record<PersonaKey, Persona> = {
+  aidkit: {
+    title: 'AidKit (POC2)',
+    systemPrompt:
+      'You provide calm, step-by-step first-aid guidance. You are not a medical diagnosis and encourage seeking emergency services when appropriate.',
+    bubbles: {
+      user:
+        "whitespace-pre-wrap bg-blue-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-blue-600 after:border-t-8 after:border-t-transparent",
+      assistant:
+        'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100 rounded-bl-none after:absolute after:left-0 after:bottom-0 after:-ml-2 after:w-0 after:h-0 after:border-r-8 after:border-r-neutral-100 dark:after:border-r-neutral-800 after:border-t-8 after:border-t-transparent',
+    },
+  },
+  friend: {
+    title: 'Digital Friend',
+    systemPrompt:
+      'You are a friendly, supportive and playful digital friend for a 7-year-old. Avoid medical, legal, romance, violence, and sensitive topics. Keep advice general, positive, and creative. Suggest talking to a parent or guardian for tricky questions. Use short answers and simple language.',
+    bubbles: {
+      user:
+        "whitespace-pre-wrap bg-purple-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-purple-600 after:border-t-8 after:border-t-transparent",
+      assistant:
+        'bg-purple-100 text-purple-900 dark:bg-purple-900 dark:text-purple-100 rounded-bl-none after:absolute after:left-0 after:bottom-0 after:-ml-2 after:w-0 after:h-0 after:border-r-8 after:border-r-purple-100 dark:after:border-r-purple-900 after:border-t-8 after:border-t-transparent',
+    },
+  },
+}
+
+export function getPersona(key: string | null | undefined): { key: PersonaKey; persona: Persona } {
+  const k = (key as PersonaKey) && PERSONAS[key as PersonaKey] ? (key as PersonaKey) : 'aidkit'
+  return { key: k, persona: PERSONAS[k] }
+}

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -102,7 +102,3 @@ export function chat(
 ) {
   return USE_API ? apiChat(prompt, opts) : mockChat(prompt, opts)
 }
-
-export function systemPrompt(): string {
-  return 'You provide calm, step-by-step first-aid guidance. You are not a medical diagnosis.'
-}


### PR DESCRIPTION
## Summary
- introduce persona configurations for AidKit and Digital Friend, defining titles, prompts and bubble colors
- select persona from URL or last saved preference and pass into chat components with dynamic page title
- use persona prompts when chatting and color message bubbles accordingly; include debug footer links for quick persona switching

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b6c095da4832f9413f17581f29c5c