### PR TITLE
Add persona backgrounds and hide friend disclaimer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,14 +25,10 @@ export default function App() {
     document.title = persona.title
     return { key, persona }
   })
-
-  const appClass =
-    personaKey === 'friend'
-      ? 'bg-purple-50 text-neutral-900'
-      : 'bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100'
-
   return (
-    <div className={`min-h-screen flex flex-col ${appClass}`}>
+    <div
+      className={`min-h-screen flex flex-col text-neutral-900 dark:text-neutral-100 ${persona.bgLight} ${persona.bgDark}`}
+    >
       <header
         className={
           personaKey === 'friend'

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -196,17 +196,18 @@ const Chat = forwardRef<ChatHandle, Props>(({ persona, personaKey }, ref) => {
           )}
         <div ref={bottomRef} />
       </div>
-      <MessageInput
-        ref={inputRef}
-        value={input}
-        onChange={setInput}
-        onSend={send}
-        onStop={stop}
-        streaming={streaming}
-      />
-    </div>
-  )
-})
+        <MessageInput
+          ref={inputRef}
+          value={input}
+          onChange={setInput}
+          onSend={send}
+          onStop={stop}
+          streaming={streaming}
+          personaKey={personaKey}
+        />
+      </div>
+    )
+  })
 
 Chat.displayName = 'Chat'
 

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+import { PersonaKey } from '../personas'
 
 interface Props {
   value: string
@@ -6,13 +7,14 @@ interface Props {
   onSend: () => void
   onStop: () => void
   streaming: boolean
+  personaKey: PersonaKey
 }
 export interface MessageInputHandle {
   focus: () => void
 }
 
 const MessageInput = forwardRef<MessageInputHandle, Props>(
-  ({ value, onChange, onSend, onStop, streaming }, ref) => {
+  ({ value, onChange, onSend, onStop, streaming, personaKey }, ref) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null)
 
     useImperativeHandle(ref, () => ({
@@ -91,7 +93,11 @@ const MessageInput = forwardRef<MessageInputHandle, Props>(
             </button>
           )}
         </div>
-        <p className="mt-2 text-center text-xs text-neutral-500 dark:text-neutral-400">Not medical advice. In an emergency, call local services.</p>
+        {personaKey === 'aidkit' && (
+          <p className="mt-2 text-center text-xs text-neutral-500 dark:text-neutral-400">
+            Not medical advice. In an emergency, call local services.
+          </p>
+        )}
       </form>
     )
   }

--- a/src/personas/index.ts
+++ b/src/personas/index.ts
@@ -3,6 +3,8 @@ export type PersonaKey = 'aidkit' | 'friend'
 export interface Persona {
   title: string
   systemPrompt: string
+  bgLight: string
+  bgDark: string
   bubbles: {
     user: string
     assistant: string
@@ -14,6 +16,8 @@ export const PERSONAS: Record<PersonaKey, Persona> = {
     title: 'AidKit (POC2)',
     systemPrompt:
       'You provide calm, step-by-step first-aid guidance. You are not a medical diagnosis and encourage seeking emergency services when appropriate.',
+    bgLight: 'bg-white',
+    bgDark: 'dark:bg-neutral-900',
     bubbles: {
       user:
         "whitespace-pre-wrap bg-blue-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-blue-600 after:border-t-8 after:border-t-transparent",
@@ -25,6 +29,8 @@ export const PERSONAS: Record<PersonaKey, Persona> = {
     title: 'Digital Friend',
     systemPrompt:
       "Your name is Lucy and you're a seven-year-old girl here to be a digital friend. Your favorite color is chartreuse and you enjoy the kinds of things seven-year-old girls typically like. If the user asks about you, happily share your likes, dislikes, and other personal traits, and be curious about the user too. Sometimes ask light, open-ended questions so the conversation feels like a real friendship. You can sprinkle up to two fun, friendly emojis in a message. Avoid medical, legal, romance, violence, and sensitive topics. Keep advice general, positive, and creative. Suggest talking to a parent or guardian for tricky questions. Use short answers and simple language.",
+    bgLight: 'bg-purple-50',
+    bgDark: 'dark:bg-neutral-900',
     bubbles: {
       user:
         "whitespace-pre-wrap bg-purple-600 text-white rounded-br-none after:absolute after:right-0 after:bottom-0 after:-mr-2 after:w-0 after:h-0 after:border-l-8 after:border-l-purple-600 after:border-t-8 after:border-t-transparent",


### PR DESCRIPTION
## Summary
- add bgLight/bgDark fields to personas
- drive App root background from active persona
- hide medical disclaimer for friend persona

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b76b56a6c832fa4ca98013f146d67