### PR TITLE
feat: add optional Slack logging

### DIFF
--- a/api/log.ts
+++ b/api/log.ts
@@ -1,0 +1,46 @@
+// Minimal process type for accessing environment variables
+declare const process: { env: Record<string, string | undefined> };
+
+export const config = { runtime: 'nodejs18.x' };
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+  if (!req.headers.get('content-type')?.includes('application/json')) {
+    return new Response('Bad Request', { status: 400 });
+  }
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response('Invalid JSON body', { status: 400 });
+  }
+  const { ts, personaId, role, text, sessionId, userAgent, path } = body ?? {};
+  if (
+    typeof ts !== 'number' ||
+    typeof personaId !== 'string' ||
+    (role !== 'user' && role !== 'assistant') ||
+    typeof text !== 'string' ||
+    typeof sessionId !== 'string'
+  ) {
+    return new Response('Bad Request', { status: 400 });
+  }
+  if (!process.env.SLACK_WEBHOOK_URL) {
+    return new Response(null, { status: 204 });
+  }
+  const formattedText = `[${new Date(ts).toISOString()}] persona=${personaId} session=${sessionId}\n${role}:\n${text}\nUA: ${userAgent || '-'}\nURL: ${path || new URL(req.url).pathname}`;
+  try {
+    const resp = await fetch(process.env.SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: formattedText }),
+    });
+    if (!resp.ok) {
+      return new Response('Upstream error', { status: 500 });
+    }
+    return new Response(null, { status: 204 });
+  } catch {
+    return new Response('Upstream error', { status: 500 });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,11 @@ import { COMMIT_SHA, BUILD_TIME } from './lib/version'
 import DebugOverlay from './components/DebugOverlay'
 import AboutModal from './components/AboutModal'
 import PrivacyModal from './components/PrivacyModal'
+import LoggingNotice from './components/LoggingNotice'
 import { getPersona } from './personas'
 import { getItem, setItem } from './lib/storage'
 import { isDebug } from './lib/debug'
+import { isLoggingEnabled, hasLogConsent } from './lib/remoteLog'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -29,6 +31,7 @@ export default function App() {
     <div
       className={`min-h-screen flex flex-col text-neutral-900 dark:text-neutral-100 ${persona.bgLight} ${persona.bgDark}`}
     >
+      <LoggingNotice />
       <header
         className={
           personaKey === 'friend'
@@ -77,9 +80,12 @@ export default function App() {
             <a href="?persona=aidkit&debug=1" className="underline mr-2">
               AidKit
             </a>
-            <a href="?persona=friend&debug=1" className="underline">
+            <a href="?persona=friend&debug=1" className="underline mr-2">
               Friend
             </a>
+            <span className="inline-block border px-1 rounded text-[10px]">
+              Logging: {isLoggingEnabled() && hasLogConsent() ? 'ON' : 'OFF'}
+            </span>
           </div>
         )}
       </footer>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -4,6 +4,7 @@ import { getItem, setItem } from '../lib/storage'
 import { uuid } from '../lib/uuid'
 import { log, isDebug } from '../lib/debug'
 import { appendChunk, normalizeListBoundary } from '../lib/stream'
+import { logEvent } from '../lib/remoteLog'
 import MessageBubble from './MessageBubble'
 import MessageInput, { MessageInputHandle } from './MessageInput'
 import { Persona, PersonaKey } from '../personas'
@@ -73,6 +74,7 @@ const Chat = forwardRef<ChatHandle, Props>(({ persona, personaKey }, ref) => {
       const assistantMsg: Message = { id: uuid(), role: 'assistant', text: '', ts: Date.now() }
       setMessages(m => [...m, userMsg, assistantMsg])
       setInput('')
+      logEvent({ personaId: persona.id, role: 'user', text: content })
       setStreaming(true)
       const controller = new AbortController()
       controllerRef.current = controller
@@ -107,10 +109,11 @@ const Chat = forwardRef<ChatHandle, Props>(({ persona, personaKey }, ref) => {
           setStreaming(false)
           controllerRef.current = undefined
         }
+        logEvent({ personaId: persona.id, role: 'assistant', text: assistantMsg.text })
       } catch (err) {
         log(err)
-      console.error(err)
-    }
+        console.error(err)
+      }
   }
 
   const retry = async () => {
@@ -165,6 +168,7 @@ const Chat = forwardRef<ChatHandle, Props>(({ persona, personaKey }, ref) => {
         setStreaming(false)
         controllerRef.current = undefined
       }
+      logEvent({ personaId: persona.id, role: 'assistant', text: last.text })
     } catch (err) {
       log(err)
       console.error(err)

--- a/src/components/LoggingNotice.tsx
+++ b/src/components/LoggingNotice.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react'
+import { isLoggingEnabled, hasLogConsent } from '../lib/remoteLog'
+
+export default function LoggingNotice() {
+  const [hidden, setHidden] = useState(false)
+  if (!isLoggingEnabled() || hasLogConsent() || hidden) return null
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 bg-yellow-100 text-gray-800 text-sm p-2 flex items-center justify-center gap-2">
+      <span className="text-center">
+        Logging is ON so a parent can review messages for this session. No personal data beyond message text is intentionally collected.
+      </span>
+      <button
+        className="underline"
+        onClick={() => {
+          localStorage.setItem('poc2.logConsent', 'yes')
+          setHidden(true)
+        }}
+      >
+        Allow
+      </button>
+      <button
+        className="underline"
+        onClick={() => {
+          const url = new URL(location.href)
+          url.searchParams.delete('log')
+          location.href = url.pathname + url.search
+        }}
+      >
+        Disable
+      </button>
+    </div>
+  )
+}

--- a/src/lib/remoteLog.ts
+++ b/src/lib/remoteLog.ts
@@ -1,0 +1,38 @@
+import { uuid } from './uuid'
+
+export function isLoggingEnabled() {
+  return new URLSearchParams(location.search).has('log')
+}
+
+export function hasLogConsent() {
+  return localStorage.getItem('poc2.logConsent') === 'yes'
+}
+
+export function getSessionId(): string {
+  const existing = localStorage.getItem('poc2.sessionId')
+  if (existing) return existing
+  const newId = uuid()
+  localStorage.setItem('poc2.sessionId', newId)
+  return newId
+}
+
+export async function logEvent(evt: { personaId: string; role: 'user' | 'assistant'; text: string }) {
+  if (!isLoggingEnabled() || !hasLogConsent()) return
+  const truncated = evt.text.slice(0, 4000)
+  const body = {
+    ts: Date.now(),
+    personaId: evt.personaId,
+    role: evt.role,
+    text: truncated,
+    sessionId: getSessionId(),
+    userAgent: navigator.userAgent,
+    path: location.pathname + location.search,
+  }
+  try {
+    await fetch('/api/log', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  } catch {}
+}

--- a/src/personas/index.ts
+++ b/src/personas/index.ts
@@ -1,6 +1,7 @@
 export type PersonaKey = 'aidkit' | 'friend'
 
 export interface Persona {
+  id: PersonaKey
   title: string
   systemPrompt: string
   bgLight: string
@@ -13,6 +14,7 @@ export interface Persona {
 
 export const PERSONAS: Record<PersonaKey, Persona> = {
   aidkit: {
+    id: 'aidkit',
     title: 'AidKit (POC2)',
     systemPrompt:
       'You provide calm, step-by-step first-aid guidance. You are not a medical diagnosis and encourage seeking emergency services when appropriate.',
@@ -26,6 +28,7 @@ export const PERSONAS: Record<PersonaKey, Persona> = {
     },
   },
   friend: {
+    id: 'friend',
     title: 'Digital Friend',
     systemPrompt:
       "Your name is Lucy and you're a seven-year-old girl here to be a digital friend. Your favorite color is chartreuse and you enjoy the kinds of things seven-year-old girls typically like. If the user asks about you, happily share your likes, dislikes, and other personal traits, and be curious about the user too. Sometimes ask light, open-ended questions so the conversation feels like a real friendship. You can sprinkle up to two fun, friendly emojis in a message. Avoid medical, legal, romance, violence, and sensitive topics. Keep advice general, positive, and creative. Suggest talking to a parent or guardian for tricky questions. Use short answers and simple language.",


### PR DESCRIPTION
## Summary
- add `/api/log` endpoint to forward chat transcripts to Slack
- integrate optional client-side logger with consent banner
- wire logging into chat flow and debug footer badge

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689bc0211070832fbab543d70dcae88f