### PR TITLE
feat(logging): send logs to Discord webhook

### DIFF
--- a/api/log.ts
+++ b/api/log.ts
@@ -1,46 +1,64 @@
 // Minimal process type for accessing environment variables
-declare const process: { env: Record<string, string | undefined> };
+declare const process: { env: Record<string, string | undefined> }
 
-export const config = { runtime: 'nodejs18.x' };
+export const config = { runtime: 'nodejs18.x' }
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405 });
+    return new Response('Method Not Allowed', { status: 405 })
   }
   if (!req.headers.get('content-type')?.includes('application/json')) {
-    return new Response('Bad Request', { status: 400 });
+    return new Response('Bad Request', { status: 400 })
   }
-  let body: any;
+
+  const url = process.env.WEBHOOK_URL
+  if (!url) {
+    return new Response(null, { status: 204 })
+  }
+
+  let body: any
   try {
-    body = await req.json();
+    body = await req.json()
   } catch {
-    return new Response('Invalid JSON body', { status: 400 });
+    return new Response('Bad Request', { status: 400 })
   }
-  const { ts, personaId, role, text, sessionId, userAgent, path } = body ?? {};
+
+  const { ts, personaId, role, text, sessionId, userAgent, path } = body ?? {}
   if (
     typeof ts !== 'number' ||
     typeof personaId !== 'string' ||
     (role !== 'user' && role !== 'assistant') ||
     typeof text !== 'string' ||
-    typeof sessionId !== 'string'
+    typeof sessionId !== 'string' ||
+    (userAgent !== undefined && typeof userAgent !== 'string') ||
+    (path !== undefined && typeof path !== 'string')
   ) {
-    return new Response('Bad Request', { status: 400 });
+    return new Response('Bad Request', { status: 400 })
   }
-  if (!process.env.SLACK_WEBHOOK_URL) {
-    return new Response(null, { status: 204 });
-  }
-  const formattedText = `[${new Date(ts).toISOString()}] persona=${personaId} session=${sessionId}\n${role}:\n${text}\nUA: ${userAgent || '-'}\nURL: ${path || new URL(req.url).pathname}`;
+
+  const hdr = `[${new Date(ts).toISOString()}] persona=${personaId} session=${sessionId}`
+  const ua = userAgent ? `\nUA: ${userAgent}` : ''
+  const urlPath = path ? `\nURL: ${path}` : ''
+  const bodyText = `\n${role}:\n${text}`
+  let content = `${hdr}${ua}${urlPath}${bodyText}`
+  if (content.length > 1800) content = content.slice(0, 1797) + '...'
+
   try {
-    const resp = await fetch(process.env.SLACK_WEBHOOK_URL, {
+    const resp = await fetch(url, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ text: formattedText }),
-    });
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [] },
+        username: 'POC2 Logger',
+      }),
+    })
     if (!resp.ok) {
-      return new Response('Upstream error', { status: 500 });
+      return new Response('Upstream error', { status: 500 })
     }
-    return new Response(null, { status: 204 });
+    return new Response(null, { status: 204 })
   } catch {
-    return new Response('Upstream error', { status: 500 });
+    return new Response('Upstream error', { status: 500 })
   }
 }
+

--- a/src/components/LoggingNotice.tsx
+++ b/src/components/LoggingNotice.tsx
@@ -7,7 +7,7 @@ export default function LoggingNotice() {
   return (
     <div className="fixed top-0 left-0 right-0 z-50 bg-yellow-100 text-gray-800 text-sm p-2 flex items-center justify-center gap-2">
       <span className="text-center">
-        Logging is ON so a parent can review messages for this session. No personal data beyond message text is intentionally collected.
+        Logging is ON so a parent can review messages for this session.
       </span>
       <button
         className="underline"

--- a/src/lib/remoteLog.ts
+++ b/src/lib/remoteLog.ts
@@ -1,7 +1,7 @@
 import { uuid } from './uuid'
 
 export function isLoggingEnabled() {
-  return new URLSearchParams(location.search).has('log')
+  return new URLSearchParams(location.search).get('log') === '1'
 }
 
 export function hasLogConsent() {


### PR DESCRIPTION
## Summary
- log API posts chat events to Discord via generic webhook
- check `?log=1` plus user consent before sending logs
- clarify logging notice copy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bc51188ac832f83ec69983aa7b265