### PR TITLE
chore: update log API to default Node.js runtime

### DIFF
--- a/api/log.ts
+++ b/api/log.ts
@@ -1,7 +1,7 @@
 // Minimal process type for accessing environment variables
 declare const process: { env: Record<string, string | undefined> }
 
-export const config = { runtime: 'nodejs18.x' }
+export const config = { runtime: 'nodejs' }
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'POST') {


### PR DESCRIPTION
## Summary
- use `nodejs` runtime for log endpoint to match Vercel's supported runtimes

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bc6882134832f98b6ee18e0ad09f5