### PR TITLE
Always-on logging gated by consent

### DIFF
--- a/api/log.js
+++ b/api/log.js
@@ -3,7 +3,7 @@ const MAX_LEN = 1800;
 module.exports = async (req, res) => {
   try {
     if (req.method === 'GET') {
-      res.status(200).json({ ok: true, hasWebhook: !!process.env.WEBHOOK_URL });
+      res.status(200).json({ ok: true, hasWebhook: !!process.env.WEBHOOK_URL, consentRequired: true });
       return;
     }
     if (req.method !== 'POST') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import LoggingNotice from './components/LoggingNotice'
 import { getPersona } from './personas'
 import { getItem, setItem } from './lib/storage'
 import { isDebug } from './lib/debug'
-import { isLoggingEnabled, hasLogConsent } from './lib/remoteLog'
+import { hasLogConsent } from './lib/remoteLog'
 
 export default function App() {
   const chatRef = useRef<ChatHandle>(null)
@@ -83,9 +83,29 @@ export default function App() {
             <a href="?persona=friend&debug=1" className="underline mr-2">
               Friend
             </a>
-            <span className="inline-block border px-1 rounded text-[10px]">
-              Logging: {isLoggingEnabled() && hasLogConsent() ? 'ON' : 'OFF'}
+            <span className="inline-block border px-1 rounded text-[10px] mr-2">
+              Logging: {hasLogConsent() ? 'ON' : 'OFF'}
             </span>
+            <a
+              href="#"
+              className="underline mr-2"
+              onClick={() => {
+                localStorage.setItem('poc2.logConsent', 'yes')
+                location.reload()
+              }}
+            >
+              Allow logging
+            </a>
+            <a
+              href="#"
+              className="underline"
+              onClick={() => {
+                localStorage.setItem('poc2.logConsent', 'no')
+                location.reload()
+              }}
+            >
+              Disable logging
+            </a>
           </div>
         )}
       </footer>

--- a/src/components/LoggingNotice.tsx
+++ b/src/components/LoggingNotice.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react'
-import { isLoggingEnabled, hasLogConsent } from '../lib/remoteLog'
+import { hasLogConsent } from '../lib/remoteLog'
 
 export default function LoggingNotice() {
   const [hidden, setHidden] = useState(false)
-  if (!isLoggingEnabled() || hasLogConsent() || hidden) return null
+  const consent = localStorage.getItem('poc2.logConsent')
+  if (hasLogConsent() || consent === 'no' || hidden) return null
   return (
     <div className="fixed top-0 left-0 right-0 z-50 bg-yellow-100 text-gray-800 text-sm p-2 flex items-center justify-center gap-2">
       <span className="text-center">
-        Logging is ON so a parent can review messages for this session.
+        Logging lets a parent review messages for this session. No personal data beyond message text is intentionally collected.
       </span>
       <button
         className="underline"
@@ -21,12 +22,11 @@ export default function LoggingNotice() {
       <button
         className="underline"
         onClick={() => {
-          const url = new URL(location.href)
-          url.searchParams.delete('log')
-          location.href = url.pathname + url.search
+          localStorage.setItem('poc2.logConsent', 'no')
+          setHidden(true)
         }}
       >
-        Disable
+        Not now
       </button>
     </div>
   )

--- a/src/lib/remoteLog.ts
+++ b/src/lib/remoteLog.ts
@@ -1,11 +1,11 @@
 import { uuid } from './uuid'
 
-export function isLoggingEnabled() {
-  return new URLSearchParams(location.search).get('log') === '1'
-}
-
 export function hasLogConsent() {
   return localStorage.getItem('poc2.logConsent') === 'yes'
+}
+
+export function revokeConsent() {
+  localStorage.removeItem('poc2.logConsent')
 }
 
 export function getSessionId(): string {
@@ -17,7 +17,7 @@ export function getSessionId(): string {
 }
 
 export async function logEvent(evt: { personaId: string; role: 'user' | 'assistant'; text: string }) {
-  if (!isLoggingEnabled() || !hasLogConsent()) return
+  if (!hasLogConsent()) return
   const truncated = evt.text.slice(0, 4000)
   const body = {
     ts: Date.now(),


### PR DESCRIPTION
## Summary
- Remove URL-based logging toggle and rely on stored consent
- Show consent banner with allow/deny options
- Add debug footer controls to view/toggle logging status
- Include consentRequired flag in log API status

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689be8106df8832f96212ddf51313948