### PR TITLE
feat: auto-update to latest build

### DIFF
--- a/api/version.js
+++ b/api/version.js
@@ -1,0 +1,8 @@
+module.exports = async (req, res) => {
+  if (req.method !== 'GET') return res.status(405).end();
+  const sha = (process.env.VERCEL_GIT_COMMIT_SHA || 'dev').slice(0,7);
+  const time = process.env.VERCEL_GIT_COMMIT_TIMESTAMP || new Date().toISOString();
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json({ sha, time });
+};
+module.exports.config = { runtime: 'nodejs' };

--- a/src/lib/autoUpdate.ts
+++ b/src/lib/autoUpdate.ts
@@ -1,0 +1,28 @@
+// Polls /api/version and auto-reloads if commit changes
+const INTERVAL_MS = 30000;
+let reloaded = false;
+
+function cacheBust(url: string) {
+  const u = new URL(url, location.href);
+  u.searchParams.set('v', String(Date.now()));
+  return u.toString();
+}
+
+export function startAutoUpdate(currentSha: string) {
+  async function check() {
+    if (reloaded) return;
+    try {
+      const r = await fetch('/api/version', { cache: 'no-store' });
+      if (!r.ok) return;
+      const { sha } = await r.json();
+      if (sha && sha !== currentSha) {
+        reloaded = true;
+        // Replace to avoid back button returning to stale page; add cache-buster
+        location.replace(cacheBust(location.href));
+      }
+    } catch {}
+  }
+  // initial check + interval
+  check();
+  setInterval(check, INTERVAL_MS);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import './index.css'
 import App from './App'
 import { initTheme } from './lib/theme'
 import { isDebug, log } from './lib/debug'
+import { COMMIT_SHA } from './lib/version'
+import { startAutoUpdate } from './lib/autoUpdate'
 
 if (isDebug()) {
   window.addEventListener('error', e => log(`error: ${e.message}`))
@@ -13,6 +15,7 @@ if (isDebug()) {
 }
 
 initTheme()
+startAutoUpdate(COMMIT_SHA)
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,33 @@
           "value": "camera=(), microphone=()"
         }
       ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- configure caching headers for root, index and assets in vercel.json
- add `/api/version` endpoint returning commit info
- poll version endpoint on the client and auto-refresh when commit changes

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d2b4b94e4832f9f6fda59af4023b0